### PR TITLE
Use Console's default helpers

### DIFF
--- a/src/SymfonyConsoleModule/Service/ConsoleApplicationFactory.php
+++ b/src/SymfonyConsoleModule/Service/ConsoleApplicationFactory.php
@@ -49,7 +49,6 @@ class ConsoleApplicationFactory implements FactoryInterface
         }
 
         $application = new Console\Application();
-        $application->setHelperSet(new HelperSet);
         if (isset($config['console']['name'])) {
             $application->setName($config['console']['name']);
         }


### PR DESCRIPTION
Do not instantiate a new `HelperSet`, but rather use Console's default. In this way, the dialog features are correctly working.
